### PR TITLE
Fix readme file loaded by setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ def get_version(*file_paths):
 version = get_version(project_name, "__init__.py")
 
 
-with open('README.md') as readme_file:
+with open('README.rst') as readme_file:
     readme = readme_file.read()
 
 requirements = [


### PR DESCRIPTION
I encountered this issue while running a fresh install. The `setup.py` is failing to load `README.md`. It looks like it should be changed to `README.rst`. 