### PR TITLE
Loris v3.0.0 updates

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@ Clone the repo and install via pip::
 If you already have loris_
 installed, then you can do::
 
-    $> pip install git+git://github.com/loris-imageserver/loris.git@9069177
+    $> pip install git+git://github.com/loris-imageserver/loris.git@v3.0.0
 
 
 This resolver uses boto3_.

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,5 +1,5 @@
 boto3
 # relying on clean setup.py without all the user/dir creation before
 # merging pull #449
-git+git://github.com/loris-imageserver/loris.git@9069177
+git+git://github.com/loris-imageserver/loris.git@v3.0.0
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -9,29 +9,26 @@
 # - requests,
 # - urllib3,
 #
-asn1crypto==0.24.0        # via cryptography
-attrs==17.4.0
-boto3==1.9.160
-botocore==1.12.160        # via boto3, s3transfer
-certifi==2018.1.18        # via requests
-cffi==1.11.5              # via cryptography
-chardet==3.0.4            # via requests
-configobj==5.0.0
+asn1crypto==0.24.0        # via cryptography, loris
+attrs==17.4.0             # via loris
+boto3==1.12.33            # via -r base.in
+botocore==1.15.33         # via boto3, s3transfer
+certifi==2018.1.18        # via loris, requests
+cffi==1.11.5              # via cryptography, loris
+chardet==3.0.4            # via loris, requests
+configobj==5.0.0          # via loris
 cryptography==2.7
-docutils==0.14            # via botocore
-enum34==1.1.6
-idna==2.6                 # via cryptography, requests
-ipaddress==1.0.19
-jmespath==0.9.4           # via boto3, botocore
-git+git://github.com/loris-imageserver/loris.git@9069177
-netaddr==0.7.19
-olefile==0.45.1           # via pillow
-pillow==4.3.0
-pycparser==2.18           # via cffi
-pyjwt==1.5.3
-python-dateutil==2.8.0    # via botocore
+docutils==0.15.2          # via botocore
+idna==2.6                 # via cryptography, loris, requests
+jmespath==0.9.5           # via boto3, botocore
+git+git://github.com/loris-imageserver/loris.git@v3.0.0  # via -r base.in
+netaddr==0.7.19           # via loris
+pillow==6.2.0             # via loris
+pycparser==2.18           # via cffi, loris
+pyjwt==1.5.3              # via loris
+python-dateutil==2.8.1    # via botocore
 requests==2.22.0
-s3transfer==0.2.0         # via boto3
-six==1.11.0               # via cryptography, python-dateutil
+s3transfer==0.3.3         # via boto3
+six==1.11.0               # via cryptography, loris, python-dateutil
 urllib3==1.25.3           # via botocore, requests
-werkzeug==0.14.1
+werkzeug==0.15.3          # via loris


### PR DESCRIPTION
This PR adds support for [loris v3.0.0](https://github.com/loris-imageserver/loris/tree/v3.0.0).

Here's a list of the upstream changes that required changes in the `s3resolver.py` module:

- Removed `mkdir_p` and replaced with `os.makedirs` ([loris a04cf2a8aba1](https://github.com/loris-imageserver/loris/commit/a04cf2a8aba1413231f2893e30922e42448c1bb6))
- Removed `fix_base_uri` method ([loris PR 478](https://github.com/loris-imageserver/loris/pull/478))
- Replaced `extra_info` with `auth_rules` ([loris PR 437](https://github.com/loris-imageserver/loris/pull/437))

Also updated the README and requirements (pip-compiled `requirements/base.in` preserving the manual security updates).

@nmaekawa How does this look to you?