### PR TITLE
Pin boto3

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,4 +1,4 @@
 git+git://github.com/loris-imageserver/loris.git@v3.1.0
-boto3
+boto3<1.16.0
 botocore<1.19.0  # restrict so urllib3 shared dependency (requests) does not clash
 

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ with open("README.rst") as readme_file:
 
 requirements = [
     "botocore<=1.18.18",
-    "boto3>=1.15.18",
+    "boto3~=1.15.18",
     # hxloris depends on https://github.com/loris-imageserver/loris.git
     # but setup.py not always can install pkgs from git repos...
     #


### PR DESCRIPTION
This PR pins the `boto3` library so that it is `>=1.15.18, ==1.15.*`. With the [new pip dependency resolver](https://pip.pypa.io/en/latest/user_guide/#changes-to-the-pip-dependency-resolver-in-20-3-2020), it seems to try every version from the latest down to 1.15.18 and then finally succeeds. This should short-circuit that process so the setup process doesn't take so long.